### PR TITLE
fix: add Owner field to IP transaction metadata in aip-3.md

### DIFF
--- a/AIPs/aip-3.md
+++ b/AIPs/aip-3.md
@@ -300,6 +300,7 @@ The new owner receives the IP at its current content version.
 | Field | Type | Size | Description | Required |
 |-------|------|------|-------------|----------|
 | ContentID | `Hash` | 32 Bytes | Permanent IP identifier | ✅ |
+| Owner | `Address` | 21 Bytes | Current owner address | ✅ |
 | Version | `uint32` | 4 Bytes | Sequential version number (previous + 1) | ✅ |
 | PreviousHash | `Hash` | 32 Bytes | Hash of previous IP transaction | ✅ |
 | BurnReason | `string` | 100 Bytes | Optional reason for destruction (UTF-8) | *3 |


### PR DESCRIPTION
# Pull Request

We have a GitHub bot that automatically merges certain PRs. Your PR will be merged immediately if it meets the following criteria:

- The PR modifies only existing draft PRs.
- The build passes successfully.
- Your GitHub username or email address is listed in the `Author` header of all affected PRs, inside `<triangular brackets>`.
- If matching by email address, it must be the one publicly listed on your GitHub profile.

## PR Checklist

Please confirm that your PR meets the following requirements:

- [x] If submitting a new AIP, I used the suggested template: [aip-template.md](https://github.com/aerium-network/aip/blob/master/aip-template.md).
- [x] I have read and followed the proposal guidelines in [AIP-1](https://aip.aerium.dev/AIPs/aip-1).

Thank you for contributing to Aerium Improvement Proposals! 🚀


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AIP-3 to add a required Owner field to applicable payload definitions.
  * Extended the IP Burn payload to include Owner before Version.
  * Clarified validation rules: burn and related payloads must specify the current owner, with ownership checked against state prior to burn.
  * Refreshed examples and tables to reflect explicit ownership in payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->